### PR TITLE
Add simple local login storage and signout

### DIFF
--- a/app/(auth)/index.tsx
+++ b/app/(auth)/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import { Image, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { saveCredentials } from '../../lib/storage'
 import authStyles from '../../styles/auth.styles'; // <-- import styles
 
 export default function LoginScreen() {
@@ -8,7 +9,8 @@ export default function LoginScreen() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
-  const handleLogin = () => {
+  const handleLogin = async () => {
+    await saveCredentials(username, password)
     router.replace('/(onboarding)/user_profile')
   }
 

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -109,7 +109,7 @@ export default function HomeScreen() {
         </AnimatedCircularProgress>
       </View>
 
-      <Text style={authStyles.miniGoalTitle}>Today's Goals</Text>
+      <Text style={authStyles.miniGoalTitle}>Today&apos;s Goals</Text>
 
       <FlatList
         data={miniGoals}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -8,10 +8,16 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native'
-import { loadUserProfile, saveUserProfile } from '../../lib/storage'
+import { useRouter } from 'expo-router'
+import {
+  clearCredentials,
+  loadUserProfile,
+  saveUserProfile,
+} from '../../lib/storage'
 import authStyles from '../../styles/auth.styles'
 
 export default function ProfileScreen() {
+  const router = useRouter()
   const [profile, setProfile] = useState<any>(null)
   const [editing, setEditing] = useState(false)
 
@@ -111,10 +117,20 @@ export default function ProfileScreen() {
             <Text style={authStyles.goalText}>Weight: {profile.weight}</Text>
             <Text style={authStyles.goalText}>Goal: {profile.goal}</Text>
 
-            <TouchableOpacity style={authStyles.button} onPress={() => setEditing(true)}>
-              <Text style={authStyles.buttonText}>Edit Profile</Text>
-            </TouchableOpacity>
-          </View>
+          <TouchableOpacity style={authStyles.button} onPress={() => setEditing(true)}>
+            <Text style={authStyles.buttonText}>Edit Profile</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={authStyles.button}
+            onPress={async () => {
+              await clearCredentials()
+              Alert.alert('Signed Out')
+              router.replace('/(auth)')
+            }}
+          >
+            <Text style={authStyles.buttonText}>Sign Out</Text>
+          </TouchableOpacity>
+        </View>
         )
       )}
     </ScrollView>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,18 +1,24 @@
 import { useRouter } from 'expo-router'
 import { useEffect } from 'react'
 import { ActivityIndicator, View } from 'react-native'
-import { loadUserProfile } from '../lib/storage'
+import { loadCredentials, loadUserProfile } from '../lib/storage'
 
 export default function RootLayout() {
   const router = useRouter()
 
   useEffect(() => {
     const checkUserStatus = async () => {
+      const credentials = await loadCredentials()
+      if (!credentials) {
+        router.replace('/(auth)')
+        return
+      }
+
       const profile = await loadUserProfile()
       if (profile) {
         router.replace('/(tabs)/home')
       } else {
-        router.replace('/(auth)') // ✅ redirect to login screen
+        router.replace('/(onboarding)/user_profile')
       }
     }
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,3 +18,34 @@ export const loadUserProfile = async (): Promise<any | null> => {
     return null
   }
 }
+
+export const saveCredentials = async (username: string, password: string) => {
+  try {
+    await AsyncStorage.setItem(
+      'user-credentials',
+      JSON.stringify({ username, password })
+    )
+  } catch (e) {
+    console.error('Error saving credentials:', e)
+  }
+}
+
+export const loadCredentials = async (): Promise<
+  { username: string; password: string } | null
+> => {
+  try {
+    const json = await AsyncStorage.getItem('user-credentials')
+    return json ? JSON.parse(json) : null
+  } catch (e) {
+    console.error('Error loading credentials:', e)
+    return null
+  }
+}
+
+export const clearCredentials = async () => {
+  try {
+    await AsyncStorage.removeItem('user-credentials')
+  } catch (e) {
+    console.error('Error clearing credentials:', e)
+  }
+}


### PR DESCRIPTION
## Summary
- store credentials in AsyncStorage
- check credentials and profile when deciding navigation
- persist credentials on login
- allow sign out from profile screen
- fix Home lint warning for unescaped apostrophe

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b07baae4083239a2a594644ce3fce