### PR TITLE
Fix root layout redirection

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,34 +1,42 @@
-import { useRouter } from 'expo-router'
-import { useEffect } from 'react'
+import { Redirect, Stack } from 'expo-router'
+import { useEffect, useState } from 'react'
 import { ActivityIndicator, View } from 'react-native'
 import { loadUserProfile } from '../lib/storage'
 
 export default function RootLayout() {
-  const router = useRouter()
+  const [initialRoute, setInitialRoute] = useState<string | null>(null)
 
   useEffect(() => {
     const checkUserStatus = async () => {
       const profile = await loadUserProfile()
       if (profile) {
-        router.replace('/(tabs)/home')
+        setInitialRoute('/(tabs)/home')
       } else {
-        router.replace('/(auth)') // ✅ redirect to login screen
+        setInitialRoute('/(auth)')
       }
     }
-
     checkUserStatus()
   }, [])
 
+  if (!initialRoute) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: '#1A1A1A',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <ActivityIndicator size="large" color="#39FF14" />
+      </View>
+    )
+  }
+
   return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: '#1A1A1A',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <ActivityIndicator size="large" color="#39FF14" />
-    </View>
+    <>
+      <Stack screenOptions={{ headerShown: false }} />
+      <Redirect href={initialRoute} />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- fix initial routing in the root layout

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0e99ed0c8323b582c5cdcb8859d1