### PR TITLE
Implement BMR calculation using US units

### DIFF
--- a/app/(onboarding)/user_profile.tsx
+++ b/app/(onboarding)/user_profile.tsx
@@ -15,10 +15,11 @@ export default function UserProfile() {
   const [height, setHeight] = useState('')
   const [weight, setWeight] = useState('')
   const [goal, setGoal] = useState('Lose')
+  const [activity, setActivity] = useState('Sedentary')
 
   const handleSubmit = async () => {
-    console.log({ name, age, sex, height, weight, goal })
-    await saveUserProfile({ name, age, sex, height, weight, goal })
+    console.log({ name, age, sex, height, weight, goal, activity })
+    await saveUserProfile({ name, age, sex, height, weight, goal, activity })
     router.replace('/(tabs)/home')
   }
   return (
@@ -42,6 +43,21 @@ export default function UserProfile() {
           <Picker.Item label="Male" value="Male" />
           <Picker.Item label="Female" value="Female" />
           <Picker.Item label="Other" value="Other" />
+        </Picker>
+      </View>
+
+      <Text style={authStyles.label}>Activity Level</Text>
+      <View style={authStyles.pickerWrapper}>
+        <Picker
+          selectedValue={activity}
+          onValueChange={(itemValue) => setActivity(itemValue)}
+          style={authStyles.picker}
+        >
+          <Picker.Item label="Sedentary" value="Sedentary" />
+          <Picker.Item label="Lightly Active" value="Lightly Active" />
+          <Picker.Item label="Moderately Active" value="Moderately Active" />
+          <Picker.Item label="Very Active" value="Very Active" />
+          <Picker.Item label="Super Active" value="Super Active" />
         </Picker>
       </View>
 

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -49,7 +49,7 @@ export default function HomeScreen() {
   const calorieGoal = userProfile
     ? calculateCalorieGoal(userProfile)
     : 2000
-  const caloriesEaten = 1200
+  const caloriesEaten = 0
   const fillPercent = (caloriesEaten / calorieGoal) * 100
 
   const toggleGoal = (id: string) => {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -28,6 +28,7 @@ export default function ProfileScreen() {
     height: '',
     weight: '',
     goal: '',
+    activity: '',
   })
 
   useEffect(() => {
@@ -98,6 +99,13 @@ export default function ProfileScreen() {
           />
           <TextInput
             style={authStyles.input}
+            value={form.activity}
+            placeholder="Activity Level"
+            placeholderTextColor="#aaa"
+            onChangeText={(text) => handleChange('activity', text)}
+          />
+          <TextInput
+            style={authStyles.input}
             value={form.goal}
             placeholder="Goal"
             placeholderTextColor="#aaa"
@@ -115,6 +123,7 @@ export default function ProfileScreen() {
             <Text style={authStyles.goalText}>Sex: {profile.sex}</Text>
             <Text style={authStyles.goalText}>Height: {profile.height}</Text>
             <Text style={authStyles.goalText}>Weight: {profile.weight}</Text>
+            <Text style={authStyles.goalText}>Activity: {profile.activity}</Text>
             <Text style={authStyles.goalText}>Goal: {profile.goal}</Text>
 
           <TouchableOpacity style={authStyles.button} onPress={() => setEditing(true)}>

--- a/lib/calorie.ts
+++ b/lib/calorie.ts
@@ -4,6 +4,7 @@ export type UserProfile = {
   height: string
   weight: string
   goal: string
+  activity?: string
 }
 
 /**
@@ -12,17 +13,28 @@ export type UserProfile = {
  */
 export const calculateCalorieGoal = (profile: UserProfile): number => {
   const age = parseFloat(profile.age)
-  const heightCm = parseFloat(profile.height) * 2.54
-  const weightKg = parseFloat(profile.weight) / 2.205
+  const heightIn = parseFloat(profile.height)
+  const weightLb = parseFloat(profile.weight)
 
-  // default to male formula if sex is not Male or Female
   const isFemale = profile.sex.toLowerCase() === 'female'
 
-  const bmr =
-    10 * weightKg + 6.25 * heightCm - 5 * age + (isFemale ? -161 : 5)
+  const bmr = isFemale
+    ? 655 + 4.35 * weightLb + 4.7 * heightIn - 4.7 * age
+    : 66 + 6.23 * weightLb + 12.7 * heightIn - 6.8 * age
 
-  // assume sedentary activity level
-  let daily = bmr * 1.2
+  const activityMultiplierMap: Record<string, number> = {
+    Sedentary: 1.2,
+    'Lightly Active': 1.375,
+    'Moderately Active': 1.55,
+    'Very Active': 1.725,
+    'Super Active': 1.9,
+  }
+
+  const multiplier = profile.activity
+    ? activityMultiplierMap[profile.activity] || 1.2
+    : 1.2
+
+  let daily = bmr * multiplier
 
   switch (profile.goal.toLowerCase()) {
     case 'lose':


### PR DESCRIPTION
## Summary
- add activity level option to onboarding
- show activity level in profile and allow editing
- switch calorie formula to US units with activity multiplier
- start calorie ring progress at zero

## Testing
- `npm install`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_684b3ab55b4883239d8a026cc79b0d90