### PR TITLE
Improve profile editor and calorie updates

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,6 +1,6 @@
 // app/(tabs)/home.tsx
 import DateTimePicker from '@react-native-community/datetimepicker'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
   Alert,
   Button,
@@ -13,6 +13,7 @@ import {
   View,
 } from 'react-native'
 import { AnimatedCircularProgress } from 'react-native-circular-progress'
+import { useFocusEffect } from '@react-navigation/native'
 import { loadUserProfile } from '../../lib/storage'
 import { calculateCalorieGoal, UserProfile } from '../../lib/calorie'
 import authStyles from '../../styles/auth.styles'
@@ -31,15 +32,17 @@ export default function HomeScreen() {
   const [deadline, setDeadline] = useState<Date | undefined>()
   const [showDatePicker, setShowDatePicker] = useState(false)
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      const profile = await loadUserProfile()
-      if (profile) {
-        setUserProfile(profile)
+  useFocusEffect(
+    useCallback(() => {
+      const fetchProfile = async () => {
+        const profile = await loadUserProfile()
+        if (profile) {
+          setUserProfile(profile)
+        }
       }
-    }
-    fetchProfile()
-  }, [])
+      fetchProfile()
+    }, [])
+  )
 
   useEffect(() => {
     const interval = setInterval(checkDeadlines, 60000) // check every 60 sec
@@ -106,7 +109,7 @@ export default function HomeScreen() {
         >
           {() => (
             <Text style={authStyles.progressText}>
-              {caloriesEaten} / {calorieGoal} kcal
+              {caloriesEaten} / {calorieGoal} cal
             </Text>
           )}
         </AnimatedCircularProgress>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -8,6 +8,7 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native'
+import { Picker } from '@react-native-picker/picker'
 import { useRouter } from 'expo-router'
 import {
   clearCredentials,
@@ -74,13 +75,19 @@ export default function ProfileScreen() {
             keyboardType="numeric"
             onChangeText={(text) => handleChange('age', text)}
           />
-          <TextInput
-            style={authStyles.input}
-            value={form.sex}
-            placeholder="Sex"
-            placeholderTextColor="#aaa"
-            onChangeText={(text) => handleChange('sex', text)}
-          />
+          <Text style={authStyles.label}>Sex</Text>
+          <View style={authStyles.pickerWrapper}>
+            <Picker
+              selectedValue={form.sex}
+              onValueChange={(val) => handleChange('sex', val)}
+              style={authStyles.picker}
+              dropdownIconColor="#39FF14"
+            >
+              <Picker.Item label="Male" value="Male" />
+              <Picker.Item label="Female" value="Female" />
+              <Picker.Item label="Other" value="Other" />
+            </Picker>
+          </View>
           <TextInput
             style={authStyles.input}
             value={form.height}
@@ -97,20 +104,34 @@ export default function ProfileScreen() {
             keyboardType="numeric"
             onChangeText={(text) => handleChange('weight', text)}
           />
-          <TextInput
-            style={authStyles.input}
-            value={form.activity}
-            placeholder="Activity Level"
-            placeholderTextColor="#aaa"
-            onChangeText={(text) => handleChange('activity', text)}
-          />
-          <TextInput
-            style={authStyles.input}
-            value={form.goal}
-            placeholder="Goal"
-            placeholderTextColor="#aaa"
-            onChangeText={(text) => handleChange('goal', text)}
-          />
+          <Text style={authStyles.label}>Activity Level</Text>
+          <View style={authStyles.pickerWrapper}>
+            <Picker
+              selectedValue={form.activity}
+              onValueChange={(val) => handleChange('activity', val)}
+              style={authStyles.picker}
+              dropdownIconColor="#39FF14"
+            >
+              <Picker.Item label="Sedentary" value="Sedentary" />
+              <Picker.Item label="Lightly Active" value="Lightly Active" />
+              <Picker.Item label="Moderately Active" value="Moderately Active" />
+              <Picker.Item label="Very Active" value="Very Active" />
+              <Picker.Item label="Super Active" value="Super Active" />
+            </Picker>
+          </View>
+          <Text style={authStyles.label}>Goal</Text>
+          <View style={authStyles.pickerWrapper}>
+            <Picker
+              selectedValue={form.goal}
+              onValueChange={(val) => handleChange('goal', val)}
+              style={authStyles.picker}
+              dropdownIconColor="#39FF14"
+            >
+              <Picker.Item label="Lose Weight" value="Lose" />
+              <Picker.Item label="Maintain Weight" value="Maintain" />
+              <Picker.Item label="Gain Weight" value="Gain" />
+            </Picker>
+          </View>
           <TouchableOpacity style={authStyles.button} onPress={handleSave}>
             <Text style={authStyles.buttonText}>Save</Text>
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- update profile editor to use dropdown pickers
- refresh user profile on home when the tab focuses
- show calories using `cal` instead of `kcal`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c42fefe7c83238c8cf2df3c11fe76