### PR TITLE
Add food logging and calorie progress

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -16,6 +16,7 @@ import { AnimatedCircularProgress } from 'react-native-circular-progress'
 import { useFocusEffect } from '@react-navigation/native'
 import { loadUserProfile } from '../../lib/storage'
 import { calculateCalorieGoal, UserProfile } from '../../lib/calorie'
+import { getTodaysCalories } from '../../lib/food'
 import authStyles from '../../styles/auth.styles'
 
 export default function HomeScreen() {
@@ -31,6 +32,7 @@ export default function HomeScreen() {
   const [newGoalText, setNewGoalText] = useState('')
   const [deadline, setDeadline] = useState<Date | undefined>()
   const [showDatePicker, setShowDatePicker] = useState(false)
+  const [caloriesEaten, setCaloriesEaten] = useState(0)
 
   useFocusEffect(
     useCallback(() => {
@@ -39,6 +41,8 @@ export default function HomeScreen() {
         if (profile) {
           setUserProfile(profile)
         }
+        const eaten = await getTodaysCalories()
+        setCaloriesEaten(eaten)
       }
       fetchProfile()
     }, [])
@@ -52,7 +56,6 @@ export default function HomeScreen() {
   const calorieGoal = userProfile
     ? calculateCalorieGoal(userProfile)
     : 2000
-  const caloriesEaten = 0
   const fillPercent = (caloriesEaten / calorieGoal) * 100
 
   const toggleGoal = (id: string) => {
@@ -95,7 +98,9 @@ export default function HomeScreen() {
 
   return (
     <View style={authStyles.container}>
-      <Text style={authStyles.title}>Daily Calorie Goal</Text>
+      <View style={authStyles.goalBox}>
+        <Text style={authStyles.title}>Daily Calorie Goal</Text>
+      </View>
 
       <View style={authStyles.ringCard}>
         <AnimatedCircularProgress

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -1,11 +1,32 @@
 import React, { useEffect, useState } from 'react'
-import { Text, View } from 'react-native'
+import {
+  FlatList,
+  Modal,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { Picker } from '@react-native-picker/picker'
 import { loadUserProfile } from '../../lib/storage'
 import { calculateCalorieGoal, UserProfile } from '../../lib/calorie'
+import {
+  addFoodLog,
+  FoodLog,
+  getTodayFoodLogs,
+} from '../../lib/food'
 import authStyles from '../../styles/auth.styles'
 
 export default function NutritionScreen() {
   const [goal, setGoal] = useState<number | null>(null)
+  const [logs, setLogs] = useState<FoodLog[]>([])
+  const [showModal, setShowModal] = useState(false)
+  const [form, setForm] = useState({
+    name: '',
+    calories: '',
+    servingSize: '',
+    meal: 'Breakfast',
+  })
 
   useEffect(() => {
     const fetch = async () => {
@@ -13,20 +34,111 @@ export default function NutritionScreen() {
       if (profile) {
         setGoal(calculateCalorieGoal(profile as UserProfile))
       }
+      const todayLogs = await getTodayFoodLogs()
+      setLogs(todayLogs)
     }
     fetch()
   }, [])
+
+  const handleChange = (field: string, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleAdd = async () => {
+    if (!form.name || !form.calories) return
+    const entry = await addFoodLog({
+      name: form.name,
+      calories: parseFloat(form.calories),
+      servingSize: form.servingSize,
+      meal: form.meal,
+    })
+    setLogs((prev) => [...prev, entry])
+    setForm({ name: '', calories: '', servingSize: '', meal: 'Breakfast' })
+    setShowModal(false)
+  }
 
   return (
     <View style={authStyles.container}>
       <Text style={authStyles.title}>Nutrition</Text>
       {goal ? (
-        <Text style={authStyles.goalText}>
-          Your daily calorie goal is {goal} kcal
-        </Text>
+        <View style={authStyles.goalBox}>
+          <Text style={authStyles.goalText}>
+            Your daily calorie goal is {goal} kcal
+          </Text>
+        </View>
       ) : (
         <Text style={authStyles.goalText}>Add your profile to see goals.</Text>
       )}
+
+      <TouchableOpacity
+        style={authStyles.button}
+        onPress={() => setShowModal(true)}
+      >
+        <Text style={authStyles.buttonText}>Log Food</Text>
+      </TouchableOpacity>
+
+      <FlatList
+        data={logs}
+        keyExtractor={(item) => item.id}
+        style={{ marginTop: 16, width: '100%' }}
+        renderItem={({ item }) => (
+          <Text style={authStyles.goalText}>
+            {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})
+          </Text>
+        )}
+      />
+
+      <Modal visible={showModal} animationType="slide" transparent>
+        <View style={[authStyles.container, { backgroundColor: '#000000cc' }]}>
+          <View style={authStyles.form}>
+            <TextInput
+              style={authStyles.input}
+              placeholder="Food name"
+              placeholderTextColor="#aaa"
+              value={form.name}
+              onChangeText={(t) => handleChange('name', t)}
+            />
+            <TextInput
+              style={authStyles.input}
+              placeholder="Calories"
+              placeholderTextColor="#aaa"
+              keyboardType="numeric"
+              value={form.calories}
+              onChangeText={(t) => handleChange('calories', t)}
+            />
+            <TextInput
+              style={authStyles.input}
+              placeholder="Serving size"
+              placeholderTextColor="#aaa"
+              value={form.servingSize}
+              onChangeText={(t) => handleChange('servingSize', t)}
+            />
+            <Text style={authStyles.label}>Meal</Text>
+            <View style={authStyles.pickerWrapper}>
+              <Picker
+                selectedValue={form.meal}
+                onValueChange={(v) => handleChange('meal', v)}
+                style={authStyles.picker}
+                dropdownIconColor="#39FF14"
+              >
+                <Picker.Item label="Breakfast" value="Breakfast" />
+                <Picker.Item label="Lunch" value="Lunch" />
+                <Picker.Item label="Dinner" value="Dinner" />
+                <Picker.Item label="Snack" value="Snack" />
+              </Picker>
+            </View>
+            <TouchableOpacity style={authStyles.button} onPress={handleAdd}>
+              <Text style={authStyles.buttonText}>Add</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={authStyles.button}
+              onPress={() => setShowModal(false)}
+            >
+              <Text style={authStyles.buttonText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </View>
   )
 }

--- a/lib/food.ts
+++ b/lib/food.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+export type FoodLog = {
+  id: string
+  name: string
+  calories: number
+  servingSize: string
+  meal: string
+  time: string
+}
+
+const getKeyForDate = (date: Date) => {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `food-logs-${y}-${m}-${d}`
+}
+
+export const addFoodLog = async (
+  log: Omit<FoodLog, 'id' | 'time'>
+): Promise<FoodLog> => {
+  const entry: FoodLog = {
+    id: Date.now().toString(),
+    time: new Date().toISOString(),
+    ...log,
+  }
+  const key = getKeyForDate(new Date())
+  const existing = await AsyncStorage.getItem(key)
+  const list: FoodLog[] = existing ? JSON.parse(existing) : []
+  list.push(entry)
+  await AsyncStorage.setItem(key, JSON.stringify(list))
+  return entry
+}
+
+export const getTodayFoodLogs = async (): Promise<FoodLog[]> => {
+  const key = getKeyForDate(new Date())
+  const json = await AsyncStorage.getItem(key)
+  return json ? JSON.parse(json) : []
+}
+
+export const getTodaysCalories = async (): Promise<number> => {
+  const logs = await getTodayFoodLogs()
+  return logs.reduce((sum, item) => sum + item.calories, 0)
+}

--- a/styles/auth.styles.js
+++ b/styles/auth.styles.js
@@ -45,9 +45,9 @@ const authStyles = StyleSheet.create({
   pickerWrapper: {
     backgroundColor: '#2C2C2C',
     borderRadius: 8,
-    marginBottom: 16,
+    marginBottom: 12,
     paddingHorizontal: 8,
-    height: 50,
+    height: 40,
     justifyContent: 'center',
     borderColor: '#39FF14', // optional: subtle neon border
   },
@@ -96,12 +96,21 @@ const authStyles = StyleSheet.create({
   borderRadius: 16,
   padding: 20,
   marginBottom: 24,
+  marginTop: 16,
   alignItems: 'center',
   shadowColor: '#39FF14',
   shadowOpacity: 0.2,
   shadowOffset: { width: 0, height: 0 },
   shadowRadius: 8,
-},
+  },
+  goalBox: {
+    backgroundColor: '#262626',
+    borderRadius: 12,
+    padding: 12,
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
 })
 
 export default authStyles


### PR DESCRIPTION
## Summary
- allow logging daily food intake
- display daily log and calorie goal with modal prompt
- track calories eaten on the Home screen and show progress
- tweak picker sizes and add goal box styling

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c49891e508323ba01518b2e2da261