### PR TITLE
Improve profile and home styling

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -109,6 +109,7 @@ export default function HomeScreen() {
           fill={fillPercent}
           tintColor="#39FF14"
           backgroundColor="#2C2C2C"
+          lineCap="round"
           rotation={0}
           duration={1000}
         >

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -80,7 +80,7 @@ export default function NutritionScreen() {
       <FlatList
         data={logs}
         keyExtractor={(item) => item.id}
-        style={{ marginTop: 16, width: '100%' }}
+        style={authStyles.list}
         renderItem={({ item }) => (
           <Text style={authStyles.goalText}>
             {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Redirect, Stack } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { ActivityIndicator, View } from 'react-native'
 import { loadUserProfile } from '../lib/storage'
+import authStyles from '../styles/auth.styles'
 
 // 1. Define the RootHref union type
 type RootHref = '/(tabs)/home' | '/(auth)'
@@ -24,14 +25,7 @@ export default function RootLayout() {
 
   if (!initialRoute) {
     return (
-      <View
-        style={{
-          flex: 1,
-          backgroundColor: '#1A1A1A',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
+      <View style={authStyles.loadingContainer}>
         <ActivityIndicator size="large" color="#39FF14" />
       </View>
     )

--- a/styles/auth.styles.js
+++ b/styles/auth.styles.js
@@ -5,7 +5,7 @@ const authStyles = StyleSheet.create({
   container: {
     backgroundColor: '#1A1A1A', // dark grey
     padding: 24,
-    paddingTop: 48,
+    paddingTop: 64,
     flexGrow: 1,
     flex: 1,
     justifyContent: 'center',
@@ -22,10 +22,13 @@ const authStyles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#39FF14',
     marginBottom: 24,
+    marginTop: 12,
     textAlign: 'center',
   },
   form: {
-    width: '100%',
+    width: '90%',
+    maxWidth: 400,
+    alignSelf: 'center',
     backgroundColor: '#262626', // slightly lighter than container
     borderRadius: 12,
     padding: 20,
@@ -92,16 +95,12 @@ const authStyles = StyleSheet.create({
     color: '#999',
   },
   ringCard: {
-  backgroundColor: '#262626',
-  borderRadius: 16,
-  padding: 20,
-  marginBottom: 24,
-  marginTop: 16,
-  alignItems: 'center',
-  shadowColor: '#39FF14',
-  shadowOpacity: 0.2,
-  shadowOffset: { width: 0, height: 0 },
-  shadowRadius: 8,
+    backgroundColor: '#262626',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 24,
+    marginTop: 16,
+    alignItems: 'center',
   },
   goalBox: {
     backgroundColor: '#262626',
@@ -110,6 +109,16 @@ const authStyles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
     marginBottom: 16,
+  },
+  list: {
+    marginTop: 16,
+    width: '100%',
+  },
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: '#1A1A1A',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 })
 


### PR DESCRIPTION
## Summary
- adjust global container padding and form width
- space titles from screen top
- remove neon shadow from calorie tracker
- add list and loading container styles
- apply styles in layout and screens
- round progress arc edges

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e53c45048323818860af161278a2