### PR TITLE
Improve profile editing and nutrition log styles

### DIFF
--- a/app/(onboarding)/user_profile.tsx
+++ b/app/(onboarding)/user_profile.tsx
@@ -23,7 +23,7 @@ export default function UserProfile() {
     router.replace('/(tabs)/home')
   }
   return (
-    <ScrollView contentContainerStyle={authStyles.container}>
+    <ScrollView contentContainerStyle={authStyles.scrollContainer}>
       <Text style={authStyles.title}>Let’s Get to Know You</Text>
 
       <TextInput style={authStyles.input} placeholder="Name" placeholderTextColor="#aaa" value={name} onChangeText={setName} />

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -14,12 +14,21 @@ import {
   addFoodLog,
   FoodLog,
   getTodayFoodLogs,
+  addQuickMeal,
 } from '../../lib/food'
 import authStyles from '../../styles/auth.styles'
 
 export default function NutritionScreen() {
   const [goal, setGoal] = useState<number | null>(null)
   const [logs, setLogs] = useState<FoodLog[]>([])
+  const handleSaveQuickMeal = async (log: FoodLog) => {
+    await addQuickMeal({
+      name: log.name,
+      calories: log.calories,
+      servingSize: log.servingSize,
+      meal: log.meal,
+    })
+  }
   const [showModal, setShowModal] = useState(false)
   const [form, setForm] = useState({
     name: '',
@@ -82,9 +91,17 @@ export default function NutritionScreen() {
         keyExtractor={(item) => item.id}
         style={authStyles.list}
         renderItem={({ item }) => (
-          <Text style={authStyles.goalText}>
-            {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})
-          </Text>
+          <View style={authStyles.goalBox}>
+            <Text style={authStyles.goalText}>
+              {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})
+            </Text>
+            <TouchableOpacity
+              onPress={() => handleSaveQuickMeal(item)}
+              style={{ position: 'absolute', right: 8, top: 8 }}
+            >
+              <Text>✅</Text>
+            </TouchableOpacity>
+          </View>
         )}
       />
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -55,7 +55,7 @@ export default function ProfileScreen() {
   }
 
   return (
-    <ScrollView contentContainerStyle={authStyles.container}>
+    <ScrollView contentContainerStyle={authStyles.scrollContainer}>
       <Text style={authStyles.title}>Your Profile</Text>
 
       {editing ? (

--- a/lib/food.ts
+++ b/lib/food.ts
@@ -42,3 +42,21 @@ export const getTodaysCalories = async (): Promise<number> => {
   const logs = await getTodayFoodLogs()
   return logs.reduce((sum, item) => sum + item.calories, 0)
 }
+
+const QUICK_KEY = 'quick-meals'
+
+export const addQuickMeal = async (
+  meal: Omit<FoodLog, 'id' | 'time'>
+): Promise<void> => {
+  const existing = await AsyncStorage.getItem(QUICK_KEY)
+  const list: Omit<FoodLog, 'id' | 'time'>[] = existing ? JSON.parse(existing) : []
+  list.push(meal)
+  await AsyncStorage.setItem(QUICK_KEY, JSON.stringify(list))
+}
+
+export const getQuickMeals = async (): Promise<
+  Omit<FoodLog, 'id' | 'time'>[]
+> => {
+  const json = await AsyncStorage.getItem(QUICK_KEY)
+  return json ? JSON.parse(json) : []
+}

--- a/styles/auth.styles.js
+++ b/styles/auth.styles.js
@@ -6,9 +6,15 @@ const authStyles = StyleSheet.create({
     backgroundColor: '#1A1A1A', // dark grey
     padding: 24,
     paddingTop: 64,
-    flexGrow: 1,
     flex: 1,
     justifyContent: 'center',
+    alignItems: 'center',
+  },
+  scrollContainer: {
+    backgroundColor: '#1A1A1A',
+    padding: 24,
+    paddingTop: 64,
+    flexGrow: 1,
     alignItems: 'center',
   },
   image: {


### PR DESCRIPTION
## Summary
- add `scrollContainer` style for scrollable forms
- apply new style to onboarding profile and profile screens
- display food log entries in boxes
- allow saving a food log as a quick meal via checkmark
- store quick meals in AsyncStorage

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e77c6dc883238d458fef486030e8