### PR TITLE
Update nutrition layout and quick meal saving

### DIFF
--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -2,7 +2,6 @@ import { Ionicons } from '@expo/vector-icons'
 import { Picker } from '@react-native-picker/picker'
 import React, { useEffect, useState } from 'react'
 import {
-  FlatList,
   Modal,
   ScrollView,
   Text,
@@ -101,60 +100,48 @@ export default function NutritionScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: '#1A1A1A' }}>
-      <FlatList
-        data={logs}
-        keyExtractor={(item) => item.id}
-        style={authStyles.list}
-        contentContainerStyle={authStyles.scrollContainer}
-        ListHeaderComponent={
-          <View style={{ width: '100%', alignItems: 'center' }}>
-            <Text style={authStyles.title}>Nutrition</Text>
+      <ScrollView contentContainerStyle={authStyles.scrollContainer}>
+        <Text style={authStyles.title}>Nutrition</Text>
 
-            {goal ? (
-              <View style={authStyles.goalBox}>
-                <Text style={authStyles.goalText}>
-                  Your daily calorie goal is {goal} kcal
-                </Text>
-              </View>
-            ) : (
-              <Text style={authStyles.goalText}>Add your profile to see goals.</Text>
-            )}
-
-            <TouchableOpacity
-              style={authStyles.button}
-              onPress={() => setShowModal(true)}
-            >
-              <Text style={authStyles.buttonText}>Log Food</Text>
-            </TouchableOpacity>
-
-            {quickMeals.length > 0 && (
-              <View style={{ width: '100%', alignItems: 'center' }}>
-                <Text style={authStyles.title}>Quick Meals</Text>
-                {quickMeals.map((item) => (
-                  <TouchableOpacity
-                    key={item.id}
-                    style={authStyles.goalBox}
-                    onPress={() => handleQuickLog(item)}
-                  >
-                    <Text style={authStyles.goalText}>
-                      {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            )}
-          </View>
-        }
-        renderItem={({ item }) => (
+        {goal ? (
           <View style={authStyles.goalBox}>
-            <View
-              style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              <Text style={authStyles.goalText}>
+            <Text style={authStyles.goalText}>
+              Your daily calorie goal is {goal} kcal
+            </Text>
+          </View>
+        ) : (
+          <Text style={authStyles.goalText}>Add your profile to see goals.</Text>
+        )}
+
+        <TouchableOpacity
+          style={authStyles.button}
+          onPress={() => setShowModal(true)}
+        >
+          <Text style={authStyles.buttonText}>Log Food</Text>
+        </TouchableOpacity>
+
+        {quickMeals.length > 0 && (
+          <View style={authStyles.sectionBox}>
+            <Text style={[authStyles.title, { marginBottom: 12 }]}>Quick Meals</Text>
+            {quickMeals.map((item) => (
+              <TouchableOpacity
+                key={item.id}
+                style={{ marginVertical: 4 }}
+                onPress={() => handleQuickLog(item)}
+              >
+                <Text style={authStyles.goalText}>
+                  {item.meal}: {item.name} - {item.calories} cal ({item.servingSize})
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        <View style={authStyles.sectionBox}>
+          <Text style={[authStyles.title, { marginBottom: 12 }]}>History</Text>
+          {logs.map((item) => (
+            <View key={item.id} style={authStyles.goalBox}>
+              <Text style={[authStyles.goalText, { flex: 1, marginRight: 10 }]}>
                 {item.name} {item.calories} kcal ({item.servingSize})
               </Text>
               <View style={{ flexDirection: 'row', gap: 20 }}>
@@ -166,9 +153,9 @@ export default function NutritionScreen() {
                 </TouchableOpacity>
               </View>
             </View>
-          </View>
-        )}
-      />
+          ))}
+        </View>
+      </ScrollView>
 
       <Modal visible={showModal} animationType="slide" transparent>
         <View style={[authStyles.container, { backgroundColor: '#000000cc' }]}>

--- a/lib/food.ts
+++ b/lib/food.ts
@@ -59,8 +59,17 @@ export const addQuickMeal = async (
 ): Promise<void> => {
   const existing = await AsyncStorage.getItem(QUICK_KEY)
   const list: Omit<FoodLog, 'id' | 'time'>[] = existing ? JSON.parse(existing) : []
-  list.push(meal)
-  await AsyncStorage.setItem(QUICK_KEY, JSON.stringify(list))
+  const exists = list.some(
+    (m) =>
+      m.name === meal.name &&
+      m.calories === meal.calories &&
+      m.servingSize === meal.servingSize &&
+      m.meal === meal.meal
+  )
+  if (!exists) {
+    list.push(meal)
+    await AsyncStorage.setItem(QUICK_KEY, JSON.stringify(list))
+  }
 }
 
 export const getQuickMeals = async (): Promise<

--- a/styles/auth.styles.js
+++ b/styles/auth.styles.js
@@ -109,6 +109,14 @@ const authStyles = StyleSheet.create({
     marginTop: 16,
     alignItems: 'center',
   },
+  sectionBox: {
+    backgroundColor: '#262626',
+    borderRadius: 16,
+    padding: 16,
+    marginVertical: 12,
+    width: '90%',
+    alignSelf: 'center',
+  },
   goalBox: {
   backgroundColor: '#2a2a2a',
   padding: 12,


### PR DESCRIPTION
## Summary
- adjust Nutrition layout to use sections instead of list
- ensure Quick Meals and History each show in their own boxes
- add spacing between serving size text and action icons
- prevent saving duplicate quick meals
- add `sectionBox` style for larger containers

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685319f9078883238bcc126c56af39e1