### PR TITLE
Add barcode scanning and refactor goals list

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   Modal,
   Platform,
-  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,
@@ -101,79 +100,85 @@ export default function HomeScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: '#1A1A1A' }}>
-      <ScrollView contentContainerStyle={authStyles.scrollContainer}>
-        <View style={authStyles.goalBox}>
-          <Text style={authStyles.title}>Daily Calorie Goal</Text>
-        </View>
-
-      <View style={authStyles.ringCard}>
-        <AnimatedCircularProgress
-          size={200}
-          width={16}
-          fill={fillPercent}
-          tintColor="#39FF14"
-          backgroundColor="#2C2C2C"
-          lineCap="round"
-          rotation={0}
-          duration={1000}
-        >
-          {() => (
-            <Text style={authStyles.progressText}>
-              {caloriesEaten} / {calorieGoal} cal
-            </Text>
-          )}
-        </AnimatedCircularProgress>
-      </View>
-
-        <View style={authStyles.sectionBox}>
-          <Text style={authStyles.miniGoalTitle}>Today&apos;s Goals</Text>
-
-          <FlatList
-            data={miniGoals}
-            keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
-              <TouchableOpacity onPress={() => toggleGoal(item.id)} style={authStyles.goalItem}>
-                {item.done ? (
-                  <Ionicons name="checkmark" size={20} color="#39FF14" style={authStyles.goalIcon} />
-                ) : item.missed ? (
-                  <Ionicons name="alarm" size={20} color="#FF6347" style={authStyles.goalIcon} />
-                ) : (
-                  <Ionicons name="square-outline" size={20} color="white" style={authStyles.goalIcon} />
-                )}
-                <Text
-                  style={[
-                    authStyles.goalText,
-                    item.done && authStyles.goalDone,
-                    item.missed && { color: 'red' },
-                  ]}
-                >
-                  {item.text}
-                </Text>
-              </TouchableOpacity>
+      <FlatList
+        data={miniGoals}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => toggleGoal(item.id)} style={authStyles.goalItem}>
+            {item.done ? (
+              <Ionicons name="checkmark" size={20} color="#39FF14" style={authStyles.goalIcon} />
+            ) : item.missed ? (
+              <Ionicons name="alarm" size={20} color="#FF6347" style={authStyles.goalIcon} />
+            ) : (
+              <Ionicons name="square-outline" size={20} color="white" style={authStyles.goalIcon} />
             )}
-          />
-
-          <TouchableOpacity style={authStyles.button} onPress={() => setShowAddGoal(true)}>
-            <Text style={authStyles.buttonText}>+ Add Goal</Text>
-          </TouchableOpacity>
-        </View>
-
-        <View style={authStyles.waterBox}>
-          <Text style={authStyles.waterText}>Water Intake: {waterCount} glasses</Text>
-          <View style={{ flexDirection: 'row', gap: 20 }}>
-            <TouchableOpacity
-              style={authStyles.button}
-              onPress={() => setWaterCount((c) => Math.max(0, c - 1))}
+            <Text
+              style={[
+                authStyles.goalText,
+                item.done && authStyles.goalDone,
+                item.missed && { color: 'red' },
+              ]}
             >
-              <Text style={authStyles.buttonText}>-</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={authStyles.button} onPress={() => setWaterCount((c) => c + 1)}>
-              <Text style={authStyles.buttonText}>+</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+              {item.text}
+            </Text>
+          </TouchableOpacity>
+        )}
+        ListHeaderComponent={
+          <>
+            <View style={[authStyles.goalBox, { justifyContent: 'center' }]}>
+              <Text style={authStyles.title}>Daily Calorie Goal</Text>
+            </View>
 
-      </ScrollView>
+            <View style={authStyles.ringCard}>
+              <AnimatedCircularProgress
+                size={200}
+                width={16}
+                fill={fillPercent}
+                tintColor="#39FF14"
+                backgroundColor="#2C2C2C"
+                lineCap="round"
+                rotation={0}
+                duration={1000}
+              >
+                {() => (
+                  <Text style={authStyles.progressText}>
+                    {caloriesEaten} / {calorieGoal} cal
+                  </Text>
+                )}
+              </AnimatedCircularProgress>
+            </View>
+
+            <View style={authStyles.sectionBox}>
+              <Text style={authStyles.miniGoalTitle}>Today&apos;s Goals</Text>
+            </View>
+          </>
+        }
+        ListFooterComponent={
+          <>
+            <View style={authStyles.sectionBox}>
+              <TouchableOpacity style={authStyles.button} onPress={() => setShowAddGoal(true)}>
+                <Text style={authStyles.buttonText}>+ Add Goal</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={authStyles.waterBox}>
+              <Text style={authStyles.waterText}>Water Intake: {waterCount} glasses</Text>
+              <View style={{ flexDirection: 'row', gap: 20 }}>
+                <TouchableOpacity
+                  style={authStyles.button}
+                  onPress={() => setWaterCount((c) => Math.max(0, c - 1))}
+                >
+                  <Text style={authStyles.buttonText}>-</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={authStyles.button} onPress={() => setWaterCount((c) => c + 1)}>
+                  <Text style={authStyles.buttonText}>+</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </>
+        }
+        contentContainerStyle={authStyles.scrollContainer}
+      />
 
       <Modal visible={showAddGoal} animationType="slide" transparent>
         <View style={[authStyles.container, { backgroundColor: '#000000cc' }]}>

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -21,9 +21,13 @@ import {
 } from '../../lib/food'
 import { loadUserProfile } from '../../lib/storage'
 import authStyles from '../../styles/auth.styles'
+import { useRouter, useLocalSearchParams } from 'expo-router'
 
 
 export default function NutritionScreen() {
+  const router = useRouter()
+  const params = useLocalSearchParams<{ scannedItem?: string }>()
+
   const [goal, setGoal] = useState<number | null>(null)
   const [logs, setLogs] = useState<FoodLog[]>([])
   const [quickMeals, setQuickMeals] = useState<FoodLog[]>([])
@@ -35,6 +39,21 @@ export default function NutritionScreen() {
     servingSize: '',
     meal: 'Breakfast',
   })
+
+  useEffect(() => {
+    if (params.scannedItem) {
+      try {
+        const item = JSON.parse(params.scannedItem as string)
+        setForm({
+          name: item.name,
+          calories: String(item.calories),
+          servingSize: item.servingSize,
+          meal: 'Breakfast',
+        })
+        setShowModal(true)
+      } catch {}
+    }
+  }, [params.scannedItem])
 
   const handleSaveQuickMeal = async (log: FoodLog) => {
     await addQuickMeal({
@@ -136,6 +155,12 @@ export default function NutritionScreen() {
           onPress={() => setShowModal(true)}
         >
           <Text style={authStyles.buttonText}>Log Food</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={authStyles.button}
+          onPress={() => router.push('/scanner')}
+        >
+          <Text style={authStyles.buttonText}>Scan Barcode</Text>
         </TouchableOpacity>
 
         {quickMeals.length > 0 && (

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -138,7 +138,7 @@ export default function ProfileScreen() {
         </View>
       ) : (
         profile && (
-          <View>
+          <View style={authStyles.sectionBox}>
             <Text style={authStyles.goalText}>Name: {profile.name}</Text>
             <Text style={authStyles.goalText}>Age: {profile.age}</Text>
             <Text style={authStyles.goalText}>Sex: {profile.sex}</Text>

--- a/app/scanner.tsx
+++ b/app/scanner.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react'
+import { Alert, Button, Text, View } from 'react-native'
+import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner'
+import { useRouter } from 'expo-router'
+import authStyles from '../styles/auth.styles'
+import { fetchFoodByUPC } from '../lib/nutritionix'
+
+export default function ScannerScreen() {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null)
+  const [scanned, setScanned] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const request = async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync()
+      setHasPermission(status === 'granted')
+    }
+    request()
+  }, [])
+
+  const handleBarCodeScanned = async (result: BarCodeScannerResult) => {
+    setScanned(true)
+    try {
+      const item = await fetchFoodByUPC(result.data)
+      router.push({
+        pathname: '/(tabs)/nutrition',
+        params: { scannedItem: JSON.stringify(item) },
+      })
+    } catch {
+      Alert.alert('Error', 'Failed to fetch item data')
+      router.back()
+    }
+  }
+
+  if (hasPermission === null) {
+    return (
+      <View style={authStyles.loadingContainer}>
+        <Text style={authStyles.goalText}>Requesting camera permission...</Text>
+      </View>
+    )
+  }
+
+  if (hasPermission === false) {
+    return (
+      <View style={authStyles.loadingContainer}>
+        <Text style={authStyles.goalText}>No access to camera</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <BarCodeScanner
+        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        style={{ flex: 1 }}
+      />
+      {scanned && (
+        <Button title="Tap to Scan Again" onPress={() => setScanned(false)} />
+      )}
+      <Button title="Close" onPress={() => router.back()} />
+    </View>
+  )
+}

--- a/lib/nutritionix.ts
+++ b/lib/nutritionix.ts
@@ -1,0 +1,24 @@
+export type NutritionixItem = {
+  name: string
+  calories: number
+  servingSize: string
+}
+
+export const fetchFoodByUPC = async (upc: string): Promise<NutritionixItem> => {
+  const res = await fetch(`https://trackapi.nutritionix.com/v2/search/item?upc=${upc}`, {
+    headers: {
+      'x-app-id': process.env.NUTRITIONIX_APP_ID ?? '',
+      'x-app-key': process.env.NUTRITIONIX_APP_KEY ?? '',
+    },
+  })
+  if (!res.ok) {
+    throw new Error('Request failed')
+  }
+  const json = await res.json()
+  const food = json.foods && json.foods[0]
+  return {
+    name: food?.food_name ?? 'Unknown',
+    calories: food?.nf_calories ?? 0,
+    servingSize: `${food?.serving_qty ?? ''} ${food?.serving_unit ?? ''}`,
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "53.0.12",
+        "expo-barcode-scanner": "~12.5.1",
         "expo-blur": "14.1.5",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.1",
@@ -6375,6 +6376,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-barcode-scanner": {
+      "version": "12.5.3",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-12.5.3.tgz",
+      "integrity": "sha512-aIeTiOUzPdngTIhZHhM1mOMx9CPtmYEtEkK8pAgyua3NiAKgsUN8z8bpiQWuZTrxSaqkU8fG1zGOk9E4VnNwyA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-blur": {
       "version": "14.1.5",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.1.5.tgz",
@@ -6447,6 +6460,15 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.3.0.tgz",
+      "integrity": "sha512-2kqJIO+oYM8J3GbvTUHLqTSpt1dLpOn/X0eB4U4RTuzz/faj8l/TyQELsMBLlGAkweNUuG9LqznbaBz+WuSFEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "53.0.12",
+    "expo-barcode-scanner": "~12.5.1",
     "expo-blur": "14.1.5",
     "expo-constants": "~17.1.6",
     "expo-font": "~13.3.1",


### PR DESCRIPTION
## Summary
- add expo-barcode-scanner dependency
- implement Nutritionix API helper
- create Scanner screen for barcode input
- add button to open scanner from Nutrition
- show scanned data in the log form
- convert Home screen list to use FlatList
- wrap profile display in section box

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6862afcb985c8323a4a8fceb00dfee52