### PR TITLE
Fix scanner routing and unique ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Barcode scanner
+
+To use the barcode scanner feature you must install the native module and run the app in a development build:
+
+```bash
+npx expo install expo-barcode-scanner
+npx expo prebuild
+npx expo run:ios # or expo run:android
+```
+
+After building, start the app with `npx expo start --dev-client`.

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -63,14 +63,7 @@ export default function NutritionScreen() {
       meal: log.meal,
     })
     const updated = await getQuickMeals()
-    // Ensure each quick meal has id and time fields
-    setQuickMeals(
-      updated.map((item, idx) => ({
-        ...item,
-        id: (item as any).id ?? `quickmeal-${idx}-${item.name}`,
-        time: (item as any).time ?? new Date().toISOString(),
-      }))
-    )
+    setQuickMeals(updated)
   }
 
   const handleQuickLog = async (log: FoodLog) => {
@@ -100,20 +93,9 @@ export default function NutritionScreen() {
   }
 
   const handleDeleteQuickMeal = async (meal: FoodLog) => {
-    await removeQuickMeal({
-      name: meal.name,
-      calories: meal.calories,
-      servingSize: meal.servingSize,
-      meal: meal.meal,
-    })
+    await removeQuickMeal(meal)
     const updated = await getQuickMeals()
-    setQuickMeals(
-      updated.map((item, idx) => ({
-        ...item,
-        id: (item as any).id ?? `quickmeal-${idx}-${item.name}`,
-        time: (item as any).time ?? new Date().toISOString(),
-      }))
-    )
+    setQuickMeals(updated)
   }
 
   useEffect(() => {
@@ -124,13 +106,7 @@ export default function NutritionScreen() {
       }
       setLogs(await getTodayFoodLogs())
       const quickMealsRaw = await getQuickMeals()
-      setQuickMeals(
-        quickMealsRaw.map((item, idx) => ({
-          ...item,
-          id: (item as any).id ?? `quickmeal-${idx}-${item.name}`,
-          time: (item as any).time ?? new Date().toISOString(),
-        }))
-      )
+      setQuickMeals(quickMealsRaw)
     }
     fetch()
   }, [])

--- a/app/scanner.tsx
+++ b/app/scanner.tsx
@@ -5,10 +5,20 @@ import { useRouter } from 'expo-router'
 import authStyles from '../styles/auth.styles'
 import { fetchFoodByUPC } from '../lib/nutritionix'
 
-export default function ScannerScreen() {
+export default function Page() {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null)
   const [scanned, setScanned] = useState(false)
   const router = useRouter()
+
+  if (!BarCodeScanner) {
+    return (
+      <View style={authStyles.loadingContainer}>
+        <Text style={authStyles.goalText}>
+          Barcode scanner is not available on this platform.
+        </Text>
+      </View>
+    )
+  }
 
   useEffect(() => {
     const request = async () => {

--- a/lib/food.ts
+++ b/lib/food.ts
@@ -20,7 +20,7 @@ export const addFoodLog = async (
   log: Omit<FoodLog, 'id' | 'time'>
 ): Promise<FoodLog> => {
   const entry: FoodLog = {
-    id: Date.now().toString(),
+    id: `${Date.now().toString()}-${Math.random().toString(36).slice(2, 8)}`,
     time: new Date().toISOString(),
     ...log,
   }
@@ -58,7 +58,7 @@ export const addQuickMeal = async (
   meal: Omit<FoodLog, 'id' | 'time'>
 ): Promise<void> => {
   const existing = await AsyncStorage.getItem(QUICK_KEY)
-  const list: Omit<FoodLog, 'id' | 'time'>[] = existing ? JSON.parse(existing) : []
+  const list: FoodLog[] = existing ? JSON.parse(existing) : []
   const exists = list.some(
     (m) =>
       m.name === meal.name &&
@@ -67,24 +67,24 @@ export const addQuickMeal = async (
       m.meal === meal.meal
   )
   if (!exists) {
-    list.push(meal)
+    list.push({
+      id: `${Date.now().toString()}-${Math.random().toString(36).slice(2, 8)}`,
+      time: new Date().toISOString(),
+      ...meal,
+    })
     await AsyncStorage.setItem(QUICK_KEY, JSON.stringify(list))
   }
 }
 
-export const getQuickMeals = async (): Promise<
-  Omit<FoodLog, 'id' | 'time'>[]
-> => {
+export const getQuickMeals = async (): Promise<FoodLog[]> => {
   const json = await AsyncStorage.getItem(QUICK_KEY)
   return json ? JSON.parse(json) : []
 }
 
-export const removeQuickMeal = async (
-  meal: Omit<FoodLog, 'id' | 'time'>
-): Promise<void> => {
+export const removeQuickMeal = async (meal: FoodLog): Promise<void> => {
   const existing = await AsyncStorage.getItem(QUICK_KEY)
   if (!existing) return
-  const list: Omit<FoodLog, 'id' | 'time'>[] = JSON.parse(existing)
+  const list: FoodLog[] = JSON.parse(existing)
   const index = list.findIndex(
     (m) =>
       m.name === meal.name &&

--- a/lib/goals.ts
+++ b/lib/goals.ts
@@ -7,7 +7,7 @@ export type Goal = {
 }
 
 export const createGoal = (text: string, deadline?: Date): Goal => ({
-  id: Date.now().toString(),
+  id: `${Date.now().toString()}-${Math.random().toString(36).slice(2, 8)}`,
   text,
   done: false,
   deadline,


### PR DESCRIPTION
## Summary
- ensure barcode scanner page has a default export named `Page`
- warn when barcode scanner is not available
- generate unique IDs for food logs and goals
- persist ID/time for quick meals and adjust nutrition screen
- document how to enable barcode scanning

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c8f206048323bfc40269ed358256